### PR TITLE
neard: 1.25.0 -> 1.26.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
       in
       rec {
         packages.neard = pkgs.callPackage ./neard.nix {
-          rustPlatform = mkRustPlatform "stable" "1.58.1";
+          rustPlatform = mkRustPlatform "stable" "1.60.0";
           inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation IOKit Security;
         };
 

--- a/neard.nix
+++ b/neard.nix
@@ -14,7 +14,7 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "neard";
-  version = "1.25.0";
+  version = "1.26.0";
 
   buildInputs = [
     llvm
@@ -35,15 +35,14 @@ rustPlatform.buildRustPackage rec {
     owner = "near";
     repo = "nearcore";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-7hiBqJLGIf+kNKJvMQ7KtGZm/SWLY3pT7YDlwbm3HDM=";
+    sha256 = "sha256-N3A+hy5I1/yJ3IN9gDw3m1IZ9qK8LNhn3fuXLMn23bg=";
   };
 
-  cargoSha256 = "sha256-7ORD9rE60YYRxMkSp+hXblHBYyEIq6JE+/cuJiQi7Po=";
+  cargoSha256 = "sha256-0e2Uv9u+HHOfO0QCzvKv9gaUssVu4hD3YqJpUk2Pw4k=";
 
   postPatch = ''
-    substituteInPlace neard/src/main.rs \
-      --replace 'git_version!(fallback = "unknown")' '"nix:${version}"' \
-      --replace 'use git_version' '//use git_version'
+    substituteInPlace neard/build.rs \
+      --replace 'get_git_version()?' '"nix:${version}"'
   '';
 
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";


### PR DESCRIPTION
Release to be scheduled on May 18 at 15:00 UTC, according to the announcement in NEAR Validators Telegram group.