### PR TITLE
neard-rc: 1.26.0-rc.3 -> 1.27.0-rc.1

### DIFF
--- a/neard-rc.nix
+++ b/neard-rc.nix
@@ -14,7 +14,7 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "neard-rc";
-  version = "1.26.0-rc.3";
+  version = "1.27.0-rc.1";
 
   buildInputs = [
     llvm
@@ -35,10 +35,10 @@ rustPlatform.buildRustPackage rec {
     owner = "near";
     repo = "nearcore";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-MjeCGTS9UPCfk4Wyj1yx0FnsVk7o8b/Ahf9Ex+7MUgw=";
+    sha256 = "sha256-olVS3M4mgvotl6HJKTz9E6uxriFCoq8WLD1+kJHzTFM=";
   };
 
-  cargoSha256 = "sha256-pYcdl1ufEMHFMwIGADHcRHqfGzkEZhNjjhp33T146Js=";
+  cargoSha256 = "sha256-nMNcAB4869St3cr2laTQ+LP4SjCQ0nd/IfIf0zGqu/Q=";
 
   postPatch = ''
     substituteInPlace neard/build.rs \
@@ -49,6 +49,9 @@ rustPlatform.buildRustPackage rec {
   CARGO_PROFILE_RELEASE_LTO = "thin";
   RUSTFLAGS = "-D warnings";
   NEAR_RELEASE_BUILD = "release";
+  cargoBuildFlags = [
+    "--features=nightly,performance_stats,memory_stats"
+  ];
 
   # WARNING 2021-05-16: takes ram massively, >14GiB for purely linking (debug build)!
   # NOTE 2021-07-22: vendoring seems to be broken


### PR DESCRIPTION
Release to be scheduled on May 25 at 15:00 UTC, according to the announcement in NEAR Validators Telegram group.