### PR TITLE
Remove Docker Hub repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,9 @@ jobs:
           export XDG_RUNTIME_DIR="${TMPDIR}/xdg"
           mkdir -p "${XDG_RUNTIME_DIR}"
           echo '${{ secrets.GHCR_PAT }}'       | nix develop .#ci --command skopeo --tmpdir=$TMPDIR login ghcr.io --username='${{ github.actor }}' --password-stdin
-          echo '${{ secrets.DOCKER_HUB_PAT }}' | nix develop .#ci --command skopeo --tmpdir=$TMPDIR login docker.io --username='${{ secrets.DOCKER_HUB_USERNAME }}' --password-stdin
 
           repositories=(
             ghcr.io/zentriamc/neard-nix/neard
-            docker.io/zentria/neard-nix
           )
           for repository in "${repositories[@]}"; do
             env DOCKER_REPOSITORY="${repository}" \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This targets latest stable and RC versions.
 
 ## Docker images
 
-See [docker.io/zentria/neard-nix](https://hub.docker.com/r/zentria/neard-nix/tags)  
 See [ghcr.io/zentriamc/neard-nix/neard](https://github.com/ZentriaMC/neard-nix/pkgs/container/neard-nix%2Fneard)
 
 ## Cache

--- a/ci/build_publish_docker_images.sh
+++ b/ci/build_publish_docker_images.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # nix develop .#ci --command "./ci/build_publish_docker_images.sh"
 
-repo="${DOCKER_REPOSITORY:-docker.io/zentria/neard-nix}"
+repo="${DOCKER_REPOSITORY:-ghcr.io/zentriamc/neard-nix/neard}"
 current_system="$(nix-instantiate --eval -E --json 'builtins.currentSystem' | jq -r '.')"
 system="${current_system/-darwin/-linux}"
 


### PR DESCRIPTION
[Docker is sunsetting Free Team organizations on April 14, 2023](https://web.archive.org/web/20230315021817/https://web.docker.com/rs/790-SSB-375/images/privatereposfaq.pdf)

https://hub.docker.com/r/zentria/neard-nix stops getting new image pushes on March 31, 2023 and will eventually disappear.

Please switch to [ghcr.io](https://github.com/ZentriaMC/neard-nix/pkgs/container/neard-nix%2Fneard) instead.